### PR TITLE
Adjust entry.sh to create just one crontab entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ AWSSecretKey=YourSecretAccessKey
 Add it to the container to path `/awscreds`: `docker run -v ./aws_creds_file.txt:/awscreds ...`
 
 ### Environment
+Use the following env. Variable to set the crontab timeframe.
+
+1. `CWM_CRON_TIME` ie `CWM_CRON_TIME="*/5 * * * *"` the default is `CWM_CRON_TIME="* * * * *"`
 
 Use the following env. variables for credentials:
 

--- a/entry.sh
+++ b/entry.sh
@@ -2,37 +2,91 @@
 
 _CRED_OPT=''
 # By default script gets creds automatically, but you can specify IAM role or creds
-if [ -f "/awscreds" ] && [ "`cat "/awscreds" | grep 'AWSAccessKeyId'`" ] && [ "`cat "/awscreds" | grep 'AWSSecretKey'`" ]; then
+if [ -f "/awscreds" ] && [ "$(grep 'AWSAccessKeyId' /awscreds)" ]  && [ "$(grep 'AWSSecretKey' /awscreds)" ]; then
   _CRED_OPT="--aws-credential-file=/awscreds"
   echo "Found credentials file, skipping load"
 elif [ "${AWS_ACCESS_KEY_ID}" ] && [ "${AWS_SECRET_ACCESS_KEY}" ]; then
-  _CRED_OPT="--aws-access-key-id=${AWS_ACCESS_KEY_ID} --aws-secret-key=${AWS_SECRET_ACCESS_KEY}" >> /etc/crontab
+  _CRED_OPT="--aws-access-key-id=${AWS_ACCESS_KEY_ID} --aws-secret-key=${AWS_SECRET_ACCESS_KEY}"
   echo "Found and substituted credentials from ENV"
 elif [ "${AWS_IAM_ROLE}" ]; then
-  _CRED_OPT="--aws-iam-role=${AWS_IAM_ROLE}" >> /etc/crontab
+  _CRED_OPT="--aws-iam-role=${AWS_IAM_ROLE}"
   echo "Fonnd IAM role"
 fi
 
 echo -n '' > /etc/crontab
+
+CRON_OUTPUT_BASE[0]="/aws-scripts-mon/mon-put-instance-data.pl --auto-scaling"
+
+if [ "$_CRED_OPT" ]; then
+  CRON_OUTPUT_BASE+=("${_CRED_OPT}")
+fi
+
+ARGS=()
+
+# Checks if ARGS already contains the given value
+has_arg() {
+  local element
+  for element in "${@:2}"; do
+    [ "${element}" == "${1}" ] && return 0
+  done
+  return 1
+}
+# Adds the given argument if not specified
+add_arg() {
+  local arg="${1}"
+  [ $# -ge 1 ] && local val="${2}"
+  if ! has_arg "${arg}" "${ARGS[@]}"; then
+    ARGS+=("${arg}")
+    [ $# -ge 1 ] && ARGS+=("${val}")
+  fi
+}
+# Adds the given argument duplicates ok.
+add_arg_simple() {
+  local arg="${1}"
+  [ $# -ge 1 ] && local val="${2}"
+  ARGS+=("${arg}")
+  [ $# -ge 1 ] && ARGS+=("${val}")
+}
+
 while getopts ':msd:' opt; do
   case "$opt" in
     m)
-      echo "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --auto-scaling ${_CRED_OPT} --mem-util --mem-used --mem-avail" >> /etc/crontab
-    ;;
+      add_arg "--mem-util"
+      add_arg "--mem-used"
+      add_arg "--mem-avail"
+      ;;
     d)
-      echo "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --auto-scaling ${_CRED_OPT} --disk-path=${OPTARG} --disk-space-util --disk-space-avail --disk-space-used" >> /etc/crontab
-    ;;
+      add_arg "--disk-space-util"
+      add_arg "--disk-space-avail"
+      add_arg "--disk-space-used"
+      add_arg_simple "--disk-path=${OPTARG}"
+      ;;
     s)
-      echo "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --auto-scaling ${_CRED_OPT} --swap-util --swap-used" >> /etc/crontab
-    ;;
-    :)
+      add_arg "--swap-util"
+      add_arg "--swap-used"
+      ;;
+    \?)
+      set +x
       echo "Need parameter for -${OPTARG}"
-    ;;
-    ?)
+      ;;
+    :)
+      set +x
       echo "Unsupported option -${OPTARG}"
-    ;;
+      ;;
   esac
 done
+
+# Get rid of processed options from Array
+shift "$((OPTIND-1))"
+# store remaining arguments for future use possibly
+#USER_ARGS=("${@}")
+CRON_OUTPUT_BASE=(${CRON_OUTPUT_BASE[@]} ${ARGS[@]})
+## Check for Cron arg
+if [ "$CWM_CRON_TIME" ];then
+  echo "${CWM_CRON_TIME}" "${CRON_OUTPUT_BASE[@]}" >> /etc/crontab
+else
+  echo "* * * * *" "${CRON_OUTPUT_BASE[@]}" >> /etc/crontab
+fi
 
 crontab /etc/crontab
 crond -f


### PR DESCRIPTION
- Making crontab just one entry instead of multiple.
- Adding the ability to set the crontab but defaulting to every minute.
- Updated readme to show new env variable available.

_TODO_
- Add systemd configuration template. 
- Add docker run options for limiting --privileged scope to only the needed resources for memory/disk access from container.