### PR TITLE
Default to sending cron output to /dev/null

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Use the following env. Variable to set the crontab timeframe.
 
 1. `CWM_CRON_TIME` ie `CWM_CRON_TIME="*/5 * * * *"` the default is `CWM_CRON_TIME="* * * * *"`
 
+Use the following env. Variable to set crontab to debug. The default is to pipe stdout from scripts to /dev/null
+
+1. `CWM_CRON_DEBUG` ie `CWM_CRON_DEBUG=1` the default is `CWM_CRON_DEBUG=`
+
 Use the following env. variables for credentials:
 
 1. `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`

--- a/entry.sh
+++ b/entry.sh
@@ -28,6 +28,10 @@ while getopts ':msd:' opt; do
       ARGS+=("--mem-util")
       ARGS+=("--mem-used")
       ARGS+=("--mem-avail")
+      if [ ! "$CWM_CRON_DEBUG" ];then
+        ARGS+=(">")
+        ARGS+=("/dev/null")
+      fi
       MEM_OUTPUT=(${CRON_OUTPUT_BASE[@]} ${ARGS[@]})
       ## Check for Cron arg
       if [ "$CWM_CRON_TIME" ];then
@@ -42,6 +46,10 @@ while getopts ':msd:' opt; do
       ARGS+=("--disk-space-avail")
       ARGS+=("--disk-space-used")
       ARGS+=("--disk-path=${OPTARG}")
+      if [ ! "$CWM_CRON_DEBUG" ];then
+        ARGS+=(">")
+        ARGS+=("/dev/null")
+      fi
       DISK_OUTPUT=(${CRON_OUTPUT_BASE[@]} ${ARGS[@]})
       if [ "$CWM_CRON_TIME" ];then
         echo "${CWM_CRON_TIME}" "${DISK_OUTPUT[@]}" >> /etc/crontab
@@ -53,6 +61,10 @@ while getopts ':msd:' opt; do
       ARGS=()
       ARGS+=("--swap-util")
       ARGS+=("--swap-used")
+      if [ ! "$CWM_CRON_DEBUG" ];then
+        ARGS+=(">")
+        ARGS+=("/dev/null")
+      fi
       SWAP_OUTPUT=(${CRON_OUTPUT_BASE[@]} ${ARGS[@]})
       if [ "$CWM_CRON_TIME" ];then
         echo "${CWM_CRON_TIME}" "${SWAP_OUTPUT[@]}" >> /etc/crontab


### PR DESCRIPTION
- Added logic to default to piping stdout from monitoring scripts in cronjob to /dev/null.
- Added ENV variable that can be set to any value which would then omit the piping to /dev/null.

**NOTE: since the jobs run every second it is a very noisey output that is not needed. Errors would still be output if the scripts fail.